### PR TITLE
Add Windows Phone 8.1 target.

### DIFF
--- a/Breeze.Sharp/Breeze.Sharp.csproj
+++ b/Breeze.Sharp/Breeze.Sharp.csproj
@@ -11,11 +11,12 @@
     <RootNamespace>Breeze.Sharp</RootNamespace>
     <AssemblyName>Breeze.Sharp</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>b5fec290</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -115,37 +116,39 @@
     <Compile Include="Validator.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Data.Edm.Portable">
-      <HintPath>..\packages\Microsoft.Data.Edm.5.6.1\lib\portable-net40+sl5+wp8+win8\Microsoft.Data.Edm.Portable.dll</HintPath>
+    <Reference Include="Microsoft.Data.Edm">
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.2\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData.Portable">
-      <HintPath>..\packages\Microsoft.Data.OData.5.6.1\lib\portable-net40+sl5+wp8+win8\Microsoft.Data.OData.Portable.dll</HintPath>
+    <Reference Include="Microsoft.Data.OData">
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.2\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client.Portable">
-      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.1\lib\portable-net45+sl5+wp8+win8\Microsoft.Data.Services.Client.Portable.dll</HintPath>
+    <Reference Include="Microsoft.Data.Services.Client">
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.2\lib\portable-net45+wp8+win8+wpa\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\portable-net45+wp80+win8\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.5\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net40+sl4+win8+wp71\System.Net.Http.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net40+sl4+win8+wp71\System.Net.Http.Extensions.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.Formatting">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.1.1\lib\portable-wp8+netcore45+net45\System.Net.Http.Formatting.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.2\lib\portable-wp8+netcore45+net45+wp81+wpa81\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net40+sl4+win8+wp71\System.Net.Http.Primitives.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="System.Spatial.Portable">
-      <HintPath>..\packages\System.Spatial.5.6.1\lib\portable-net40+sl5+wp8+win8\System.Spatial.Portable.dll</HintPath>
+    <Reference Include="System.Spatial">
+      <HintPath>..\packages\System.Spatial.5.6.2\lib\portable-net40+sl5+wp8+win8+wpa\System.Spatial.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Include="__RequestedFeatures.txt" />
@@ -157,10 +160,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Breeze.Sharp/EntityTypeBuilder.cs
+++ b/Breeze.Sharp/EntityTypeBuilder.cs
@@ -1,6 +1,5 @@
 ﻿
 using System.Linq;
-using System.ServiceModel.Channels;
 using System.Threading;
 using Breeze.Sharp.Core;
 using System;

--- a/Breeze.Sharp/packages.config
+++ b/Breeze.Sharp/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="portable-net45+wp80+win" />
-  <package id="Microsoft.Bcl" version="1.1.6" targetFramework="portable-net45+wp80+win" />
-  <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="portable-net45+wp80+win" />
-  <package id="Microsoft.Data.Edm" version="5.6.1" targetFramework="portable-net45+wp80+win" />
-  <package id="Microsoft.Data.OData" version="5.6.1" targetFramework="portable-net45+wp80+win" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.1" targetFramework="portable-net45+wp80+win" />
-  <package id="Microsoft.Net.Http" version="2.2.18" targetFramework="portable-net45+wp80+win" />
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="portable-net45+wp80+win" />
-  <package id="System.Spatial" version="5.6.1" targetFramework="portable-net45+wp80+win" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="portable-net45+win+wpa81+wp80" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="portable-net45+win+wpa81+wp80" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable-net45+win+wpa81+wp80" />
+  <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="portable-net45+win+wpa81+wp80" />
+  <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="portable-net45+win+wpa81+wp80" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.2" targetFramework="portable-net45+win+wpa81+wp80" />
+  <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="portable-net45+win+wpa81+wp80" />
+  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="portable-net45+win+wpa81+wp80" />
+  <package id="System.Spatial" version="5.6.2" targetFramework="portable-net45+win+wpa81+wp80" />
 </packages>

--- a/Nuget.builds/Breeze.Sharp/Breeze.Sharp.nuspec
+++ b/Nuget.builds/Breeze.Sharp/Breeze.Sharp.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>Breeze.Sharp</id>
-        <version>0.6.0.3</version>
+        <version>0.6.0.2</version>
         <title>Breeze Sharp</title>
         <authors>Jay Traband</authors>
         <owners>IdeaBlade</owners>
@@ -17,17 +17,17 @@
         <releaseNotes>Please review the BreezeSharp release notes at http://www.breezejs.com/documentation/download</releaseNotes>        
         <tags>javascript WebApi Breeze SPA</tags>
 		<dependencies>
-        <dependency id="Newtonsoft.Json" version="6.0.2" />
+        <dependency id="Newtonsoft.Json" version="6.0.4" />
 		</dependencies>
     </metadata>
     <files>
-        <file src="lib\portable-net45+wp80+win\*.pdb" target="lib\portable-net45+wp80+win\" />
-        <file src="lib\portable-net45+wp80+win\Breeze.Sharp.dll" target="lib\portable-net45+wp80+win" />       
-        <file src="lib\portable-net45+wp80+win\Microsoft.Data.Edm.Portable.dll" target="lib\portable-net45+wp80+win\" />
-        <file src="lib\portable-net45+wp80+win\Microsoft.Data.OData.Portable.dll" target="lib\portable-net45+wp80+win\" />
-        <file src="lib\portable-net45+wp80+win\Microsoft.Data.Services.Client.Portable.dll" target="lib\portable-net45+wp80+win\" />
-        <file src="lib\portable-net45+wp80+win\System.Spatial.Portable.dll" target="lib\portable-net45+wp80+win\" /> 
-        <file src="readme.txt" target="readme.txt" />
-    </files>       
-        
+      <file src="lib\portable-net45+win+wpa81+wp80\*.pdb" target="lib\portable-net45+win+wpa81+wp80\" />
+      <file src="lib\portable-net45+win+wpa81+wp80\Breeze.Sharp.dll" target="lib\portable-net45+win+wpa81+wp80" />
+      <file src="lib\portable-net45+win+wpa81+wp80\Microsoft.Data.Edm.dll" target="lib\portable-net45+win+wpa81+wp80\" />
+      <file src="lib\portable-net45+win+wpa81+wp80\Microsoft.Data.OData.dll" target="lib\portable-net45+win+wpa81+wp80\" />
+      <file src="lib\portable-net45+win+wpa81+wp80\Microsoft.Data.Services.Client.dll" target="lib\portable-net45+win+wpa81+wp80\" />
+      <file src="lib\portable-net45+win+wpa81+wp80\System.Spatial.dll" target="lib\portable-net45+win+wpa81+wp80\" />
+      <file src="readme.txt" target="readme.txt" />
+    </files>
+
 </package>

--- a/Nuget.builds/Breeze.Sharp/Default.nuspec
+++ b/Nuget.builds/Breeze.Sharp/Default.nuspec
@@ -17,16 +17,16 @@
         <releaseNotes>Please review the BreezeSharp release notes at http://www.breezejs.com/documentation/download</releaseNotes>        
         <tags>javascript WebApi Breeze SPA</tags>
 		<dependencies>
-        <dependency id="Newtonsoft.Json" version="6.0.2" />
+        <dependency id="Newtonsoft.Json" version="6.0.4" />
 		</dependencies>
     </metadata>
     <files>
-        <file src="lib\portable-net45+wp80+win\*.pdb" target="lib\portable-net45+wp80+win\" />
-        <file src="lib\portable-net45+wp80+win\Breeze.Sharp.dll" target="lib\portable-net45+wp80+win" />       
-        <file src="lib\portable-net45+wp80+win\Microsoft.Data.Edm.Portable.dll" target="lib\portable-net45+wp80+win\" />
-        <file src="lib\portable-net45+wp80+win\Microsoft.Data.OData.Portable.dll" target="lib\portable-net45+wp80+win\" />
-        <file src="lib\portable-net45+wp80+win\Microsoft.Data.Services.Client.Portable.dll" target="lib\portable-net45+wp80+win\" />
-        <file src="lib\portable-net45+wp80+win\System.Spatial.Portable.dll" target="lib\portable-net45+wp80+win\" /> 
+        <file src="lib\portable-net45+win+wpa81+wp80\*.pdb" target="lib\portable-net45+win+wpa81+wp80\" />
+        <file src="lib\portable-net45+win+wpa81+wp80\Breeze.Sharp.dll" target="lib\portable-net45+win+wpa81+wp80" />       
+        <file src="lib\portable-net45+win+wpa81+wp80\Microsoft.Data.Edm.dll" target="lib\portable-net45+win+wpa81+wp80\" />
+        <file src="lib\portable-net45+win+wpa81+wp80\Microsoft.Data.OData.dll" target="lib\portable-net45+win+wpa81+wp80\" />
+        <file src="lib\portable-net45+win+wpa81+wp80\Microsoft.Data.Services.Client.dll" target="lib\portable-net45+win+wpa81+wp80\" />
+        <file src="lib\portable-net45+win+wpa81+wp80\System.Spatial.dll" target="lib\portable-net45+win+wpa81+wp80\" /> 
         <file src="readme.txt" target="readme.txt" />
     </files>       
         

--- a/Tests/Internal/Model.Edmunds/Model.Edmunds.csproj
+++ b/Tests/Internal/Model.Edmunds/Model.Edmunds.csproj
@@ -32,9 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Tests/Internal/Model.Edmunds/packages.config
+++ b/Tests/Internal/Model.Edmunds/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" />
 </packages>

--- a/Tests/Internal/Model.Northwind.Sharp/Model.Northwind.Sharp.csproj
+++ b/Tests/Internal/Model.Northwind.Sharp/Model.Northwind.Sharp.csproj
@@ -35,8 +35,9 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
+    <Reference Include="System.Spatial, Version=5.6.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\System.Spatial.5.6.2\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -55,9 +56,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="CustomMessages1.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>CustomMessages1.Designer.cs</LastGenOutput>
@@ -69,6 +67,9 @@
       <Project>{54b1ce10-2847-4565-839a-26da3a51af38}</Project>
       <Name>Breeze.Sharp</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Tests/Internal/Model.Northwind.Sharp/packages.config
+++ b/Tests/Internal/Model.Northwind.Sharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.2" targetFramework="net45" />
 </packages>

--- a/Tests/Internal/Tests/Breeze.Sharp.Internal.Tests.csproj
+++ b/Tests/Internal/Tests/Breeze.Sharp.Internal.Tests.csproj
@@ -41,9 +41,8 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />

--- a/Tests/Internal/Tests/packages.config
+++ b/Tests/Internal/Tests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Jay,
I've added the Windows Phone 8.1 Store app target to the portable library, so Breeze.Sharp can be used to build Universal Apps and Windows Phone 8.1 Runtime apps. I haven't run any of the tests, but it builds. 
