### PR TITLE
this fixes issue when trying to set WithClientServerNamespaceMapping

### DIFF
--- a/Breeze.Sharp/NamingConvention.cs
+++ b/Breeze.Sharp/NamingConvention.cs
@@ -80,7 +80,7 @@ namespace Breeze.Sharp {
 
     public NamingConvention WithClientServerNamespaceMapping(IDictionary<String, String> clientServerNamespaceMap) {
       var clone = Clone();
-      clone._clientServerNamespaceMap = new Dictionary<string, string>(_clientServerNamespaceMap);
+      clone._clientServerNamespaceMap = new Dictionary<string, string>(clientServerNamespaceMap);
       _serverClientNamespaceMap = null;
       return clone;
     }


### PR DESCRIPTION
with Dictionary overload - _clientServerNamespaceMap is not being set due to wrong variable being passed to clone method